### PR TITLE
Add fixed circle toggle and timed selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ App estilo Chwazi desarrollada en Flutter. Permite seleccionar animaciones y ele
 - Selección aleatoria de dedos
 - Animaciones personalizadas (rebote, agrandar, etc.)
 - Preparado para agregar efectos como brillo y partículas
+- Opción "Mostrar círculo fijo" para probar animaciones
 
 ## Instalación
 
@@ -15,3 +16,4 @@ App estilo Chwazi desarrollada en Flutter. Permite seleccionar animaciones y ele
 flutter pub get
 flutter run
 
+```

--- a/lib/views/animation_selector_view.dart
+++ b/lib/views/animation_selector_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import '../models/animation_option.dart';
 import '../widgets/animated_circle.dart';
 import '../utils/touch_manager.dart';
@@ -12,24 +13,37 @@ class AnimationSelector extends StatefulWidget {
 class _AnimationSelectorState extends State<AnimationSelector> {
   AnimationOption selectedAnimation = AnimationOption.scale;
   Map<int, TouchCircle> activeTouches = {};
+  bool showFixedCircle = false;
+  Timer? _selectionTimer;
 
   void _handleTouch(PointerEvent event, {bool isUp = false}) {
     if (event is PointerDownEvent || event is PointerMoveEvent) {
       setState(() {
         activeTouches[event.pointer] = TouchCircle(
           pointerId: event.pointer,
-          position: event.position,
+          // Use the event's local position so the circle appears
+          // correctly relative to the listener's area.
+          position: event.localPosition,
           color: Colors.primaries[event.pointer % Colors.primaries.length],
         );
       });
+
+      if (event is PointerDownEvent) {
+        _selectionTimer?.cancel();
+        _selectionTimer = Timer(const Duration(seconds: 5), () {
+          if (mounted && activeTouches.isNotEmpty) {
+            _selectRandomFinger();
+          }
+        });
+      }
     } else if (isUp) {
       setState(() {
         activeTouches.remove(event.pointer);
       });
 
       if (activeTouches.isEmpty) {
-        // Al soltar todos los dedos: seleccionar uno o más
-        _selectRandomFinger(); 
+        _selectionTimer?.cancel();
+        _selectionTimer = null;
       }
     }
   }
@@ -44,7 +58,7 @@ class _AnimationSelectorState extends State<AnimationSelector> {
       context: context,
       builder: (_) => AlertDialog(
         title: const Text("¡Seleccionado!"),
-        content: Text("Ganador: ${winner.pointerId}"),
+        content: Text("Ganador chwazii: dedo ${winner.pointerId}"),
       ),
     );
   }
@@ -62,6 +76,11 @@ class _AnimationSelectorState extends State<AnimationSelector> {
                 .map((e) => DropdownMenuItem(value: e, child: Text(e.displayName)))
                 .toList(),
           ),
+          SwitchListTile(
+            title: const Text('Mostrar círculo fijo'),
+            value: showFixedCircle,
+            onChanged: (value) => setState(() => showFixedCircle = value),
+          ),
           Expanded(
             child: Listener(
               onPointerDown: _handleTouch,
@@ -75,6 +94,15 @@ class _AnimationSelectorState extends State<AnimationSelector> {
                           animationType: selectedAnimation,
                         ))
                     .toList(),
+                if (showFixedCircle)
+                  AnimatedCircle(
+                    position: Offset(
+                      MediaQuery.of(context).size.width / 2,
+                      MediaQuery.of(context).size.height / 2,
+                    ),
+                    color: Colors.grey.withOpacity(0.3),
+                    animationType: selectedAnimation,
+                  ),
               ),
             ),
           )

--- a/lib/widgets/animated_circle.dart
+++ b/lib/widgets/animated_circle.dart
@@ -45,17 +45,21 @@ class _AnimatedCircleState extends State<AnimatedCircle> with SingleTickerProvid
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      left: widget.position.dx - 25,
-      top: widget.position.dy - 25,
+      left: widget.position.dx - 40,
+      top: widget.position.dy - 40,
       child: AnimatedBuilder(
         animation: _animation,
         builder: (context, child) {
           return Transform.scale(
             scale: _animation.value,
             child: Container(
-              width: 50,
-              height: 50,
-              decoration: BoxDecoration(color: widget.color, shape: BoxShape.circle),
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: widget.color,
+                shape: BoxShape.circle,
+                border: Border.all(color: Colors.black, width: 3),
+              ),
             ),
           );
         },


### PR DESCRIPTION
## Summary
- enlarge finger circles and add visible border
- add option to toggle a fixed circle to preview animations
- delay winner selection by 5 seconds and show "chwazii" label
- document the new menu option

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772d004fe08320b34eee0c80b0424c